### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ activity.type('Accept')
   });
 ```
 
-Note that `name` will be generated for you from your `type`, `actor` and `object` if you don't set it explicitly.  `id` will also be auto-populated using the [node-uuid](https://www.npmjs.com/package/node-uuid) module
+Note that `name` will be generated for you from your `type`, `actor` and `object` if you don't set it explicitly.  `id` will also be auto-populated using the [uuid](https://www.npmjs.com/package/uuid) module
 
 
 We've added a `meta` field so that you can add any extraneous data that doesn't fit into JSON Activity Stream spec as well.  It works the same way as all of the other fields you can set.  

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const tensify = require('tensify');
 
 let activityClass = class JSONActivityStreamish {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "should": "^11.1.0"
   },
   "dependencies": {
-    "node-uuid": "^1.4.7",
-    "tensify": "0.0.2"
+    "tensify": "0.0.2",
+    "uuid": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.